### PR TITLE
Install Python first so Prolog isn't uninstalled.

### DIFF
--- a/cs50.sh
+++ b/cs50.sh
@@ -1,6 +1,33 @@
 #!/bin/bash
 set -e
 
+# Install Python 3.7
+# https://www.python.org/downloads/
+# https://stackoverflow.com/a/44758621/5156190
+apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential \
+        libbz2-dev \
+        libc6-dev \
+        libgdbm-dev \
+        libncursesw5-dev \
+        libreadline-gplv2-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        tk-dev \
+        zlib1g-dev && \
+    cd /tmp && \
+    wget https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz && \
+    tar xzf Python-3.7.3.tgz && \
+    rm -f Python-3.7.3.tgz && \
+    cd Python-3.7.3 && \
+    ./configure && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf Python-3.7.3 && \
+    pip3 install --upgrade pip
+
 # Ubuntu-specific
 apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common && \
@@ -94,33 +121,6 @@ curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs && \
     npm install -g npm `# Upgrades npm to latest` && \
     npm install -g grunt http-server nodemon
-
-# Install Python 3.7
-# https://www.python.org/downloads/
-# https://stackoverflow.com/a/44758621/5156190
-apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        build-essential \
-        libbz2-dev \
-        libc6-dev \
-        libgdbm-dev \
-        libncursesw5-dev \
-        libreadline-gplv2-dev \
-        libsqlite3-dev \
-        libssl-dev \
-        tk-dev \
-        zlib1g-dev && \
-    cd /tmp && \
-    wget https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz && \
-    tar xzf Python-3.7.3.tgz && \
-    rm -f Python-3.7.3.tgz && \
-    cd Python-3.7.3 && \
-    ./configure && \
-    make && \
-    make install && \
-    cd .. && \
-    rm -rf Python-3.7.3 && \
-    pip3 install --upgrade pip
 
 # Install Swift 5.0
 cd /tmp && \


### PR DESCRIPTION
`swi-prolog` installs fine; however later in the install script it gets removed. The following commands can be run in a sandbox to reproduce:
```
apt-get install -y swi-prolog
which prolog
apt-get install -y libreadline-gplv2-dev # This removes swi-prolog
which prolog
```
It looks like the simplest solution is to move the Python install section to the top of the shell script, which this PR does.